### PR TITLE
Null reference when DesignDocManager is using CouchbaseClientConfiguration

### DIFF
--- a/src/CouchbaseModelViews.Framework/DesignDocManager.cs
+++ b/src/CouchbaseModelViews.Framework/DesignDocManager.cs
@@ -32,9 +32,9 @@ namespace CouchbaseModelViews.Framework
 {
 	public class DesignDocManager
 	{
-		private static CouchbaseClientSection _config;
+		private static ICouchbaseClientConfiguration _config;
 		private static CouchbaseCluster _cluster;
-		
+
 		public DesignDocManager(string sectionName = "couchbase")
 		{
 			if (_cluster == null)
@@ -48,6 +48,7 @@ namespace CouchbaseModelViews.Framework
 		{
 			if (_cluster == null)
 			{
+				_config = config;
 				_cluster = new CouchbaseCluster(config);
 			}
 		}
@@ -58,20 +59,20 @@ namespace CouchbaseModelViews.Framework
 
 			try
 			{
-				_cluster.RetrieveDesignDocument(_config.Servers.Bucket, designDocName);
+				_cluster.RetrieveDesignDocument(_config.Bucket, designDocName);
 			}
 			catch (WebException ex)
 			{
 				if (!ex.Message.Contains("404")) throw ex;
 				//Do nothing on 404
 			}
-			
+
 			if (!string.IsNullOrEmpty(doc))
 			{
-				_cluster.DeleteDesignDocument(_config.Servers.Bucket, designDocName);
+				_cluster.DeleteDesignDocument(_config.Bucket, designDocName);
 			}
 
-			_cluster.CreateDesignDocument(_config.Servers.Bucket, designDocName, designDoc);
+			_cluster.CreateDesignDocument(_config.Bucket, designDocName, designDoc);
 
 			if (callback != null) callback(designDocName);
 		}
@@ -82,6 +83,6 @@ namespace CouchbaseModelViews.Framework
 			{
 				Create(key, designDocs[key], callback);
 			}
-		}		
+		}
 	}
 }


### PR DESCRIPTION
I created a new DesignDocManager and passed in an instance of CouchbaseClientConfiguration on the constructor.

When calling the create method on the DesignDocManager instance a null reference exception is thrown.

```
System.NullReferenceException was unhandled
HResult=-2147467261
Message=Object reference not set to an instance of an object.
Source=CouchbaseModelViews.Framework
StackTrace:
   at CouchbaseModelViews.Framework.DesignDocManager.Create(String designDocName, String designDoc, Action`1 callback) in c:\code\couchbase-model-views\src\CouchbaseModelViews.Framework\DesignDocManager.cs:line 61
   at CouchbaseModelViews.Framework.DesignDocManager.Create(IDictionary`2 designDocs, Action`1 callback) in c:\code\couchbase-model-views\src\CouchbaseModelViews.Framework\DesignDocManager.cs:line 83
   at CouchbaseModelViewsGenerator.Program.Main(String[] args) in c:\code\couchbase-model-views\src\CouchbaseModelViewsGenerator\Program.cs:line 48
```

When using this constructor the _config field is never set, probably because we've passed in a CouchbaseClientConfiguration rather than a CouchbaseClientSection. Whatever the reason, the exception is thrown later on when we try and get the Bucket from the configuration.
